### PR TITLE
chore: ignore Serena directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# Serena
+.serena


### PR DESCRIPTION
## Summary
- Ignore `.serena` directory in `.gitignore` to prevent committing local Serena metadata.

## Context
This keeps the repo clean of local tool artifacts.

## Test plan
- No runtime changes. Verify that `.serena` is untracked locally.