### PR TITLE
docs: add Obsidian API reference link to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@
 ## Obsidian Plugin Best Practices
 
 - **Obsidian API**: Use only official public APIs, avoid undocumented internals
+  - API Reference: https://docs.obsidian.md/Reference
 - **Plugin class**: Extend `Plugin` class, implement `onload()` and `onunload()`
 - **Settings management**: Persist settings with `loadData()` and `saveData()`
 - **Event handling**: Register events with `registerEvent()` for automatic cleanup


### PR DESCRIPTION
## Summary
- Add link to official Obsidian API documentation (https://docs.obsidian.md/Reference) in CLAUDE.md
- This helps AI agents understand available Obsidian APIs when working on the plugin

## Test plan
- [x] Verify CLAUDE.md contains the new API reference link
- [x] Ensure formatting is consistent with existing documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Obsidian Plugin Best Practices by adding a new bullet under the Obsidian API section linking to the official API Reference (https://docs.obsidian.md/Reference).
  * Improves discoverability of authoritative API docs and guides developers to up-to-date references for implementation details.
  * No changes to functionality, configuration, or usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->