### PR TITLE
feat: add template support for task notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ An Obsidian plugin for managing tasks by adding metadata (frontmatter) to notes.
     - `type`: task
   - Opens the created note automatically
 
+- **Template support**: Use custom templates for task notes
+  - Configure template file in plugin settings
+  - Supports the same template variables as Obsidian's core Templates plugin:
+    - `{{date}}`: Current date (YYYY-MM-DD)
+    - `{{time}}`: Current time (HH:mm)
+    - `{{title}}`: Task note filename (timestamp)
+    - `{{date:FORMAT}}`: Custom date format (e.g., `{{date:YYYY/MM/DD}}`)
+    - `{{time:FORMAT}}`: Custom time format (e.g., `{{time:HH:mm:ss}}`)
+
 ## Installation
 
 1. Copy `main.js`, `styles.css`, and `manifest.json` to your vault `VaultFolder/.obsidian/plugins/mono-task-note/`

--- a/settings.ts
+++ b/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, TFile, FuzzySuggestModal } from 'obsidian';
-import MonoTaskNotePlugin from './main';
+import type MonoTaskNotePlugin from './main';
 
 export interface MonoTaskNoteSettings {
 	templatePath: string;

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,77 @@
+import { App, PluginSettingTab, Setting, TFile, FuzzySuggestModal } from 'obsidian';
+import MonoTaskNotePlugin from './main';
+
+export interface MonoTaskNoteSettings {
+	templatePath: string;
+}
+
+export const DEFAULT_SETTINGS: MonoTaskNoteSettings = {
+	templatePath: ''
+};
+
+export class MonoTaskNoteSettingTab extends PluginSettingTab {
+	plugin: MonoTaskNotePlugin;
+
+	constructor(app: App, plugin: MonoTaskNotePlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+
+		containerEl.createEl('h2', { text: 'Mono Task Note Settings' });
+
+		new Setting(containerEl)
+			.setName('Template')
+			.setDesc('Select a template file for creating task notes')
+			.addText(text => {
+				text
+					.setPlaceholder('Template path')
+					.setValue(this.plugin.settings.templatePath)
+					.onChange(async (value) => {
+						this.plugin.settings.templatePath = value;
+						await this.plugin.saveSettings();
+					});
+				
+				text.inputEl.style.width = '300px';
+			})
+			.addButton(button => {
+				button
+					.setButtonText('Select')
+					.onClick(() => {
+						new TemplateSearchModal(this.app, async (file: TFile) => {
+							this.plugin.settings.templatePath = file.path;
+							await this.plugin.saveSettings();
+							this.display();
+						}).open();
+					});
+			});
+	}
+}
+
+class TemplateSearchModal extends FuzzySuggestModal<TFile> {
+	onChoose: (file: TFile) => void;
+
+	constructor(app: App, onChoose: (file: TFile) => void) {
+		super(app);
+		this.onChoose = onChoose;
+	}
+
+	getItems(): TFile[] {
+		const files = this.app.vault.getMarkdownFiles();
+		return files.filter(file => {
+			const path = file.path.toLowerCase();
+			return path.includes('template') || path.includes('テンプレート');
+		});
+	}
+
+	getItemText(file: TFile): string {
+		return file.path;
+	}
+
+	onChooseItem(file: TFile): void {
+		this.onChoose(file);
+	}
+}


### PR DESCRIPTION
## Summary
- Added configurable template support for creating task notes
- Implemented Obsidian core template variable compatibility
- Added settings page with template file selection

## Features
- Template file can be configured in plugin settings
- Supports template variables compatible with Obsidian's core Templates plugin:
  - `{{date}}`: Current date (YYYY-MM-DD)
  - `{{time}}`: Current time (HH:mm)
  - `{{title}}`: Task note filename (timestamp)
  - `{{date:FORMAT}}`: Custom date format
  - `{{time:FORMAT}}`: Custom time format
- All moment.js format tokens are supported

## Test plan
- [x] Install the plugin
- [x] Create a template file with variables (e.g., `{{date}}`, `{{time}}`, `{{title}}`)
- [x] Configure the template in plugin settings
- [x] Create a new task note using the command
- [x] Verify template variables are correctly replaced
- [x] Test custom date/time formats (e.g., `{{date:YYYY/MM/DD}}`)
- [x] Verify frontmatter is still correctly added
- [x] Test without a template configured (should work as before)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable custom template support for task notes with a picker in settings.
  * Support template variables: {{date}}, {{time}}, {{title}}, and {{date:FORMAT}} / {{time:FORMAT}}.
  * Frontmatter fields (done, due date, priority, scheduled time, type) are only populated when missing.

* **Documentation**
  * README updated with template usage, configuration instructions, and variable examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->