### PR TITLE
feat: add automatic done_at timestamp when task is marked as done

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -3,10 +3,12 @@ import type MonoTaskNotePlugin from './main';
 
 export interface MonoTaskNoteSettings {
 	templatePath: string;
+	doneAtFormat: string;
 }
 
 export const DEFAULT_SETTINGS: MonoTaskNoteSettings = {
-	templatePath: ''
+	templatePath: '',
+	doneAtFormat: ''
 };
 
 export class MonoTaskNoteSettingTab extends PluginSettingTab {
@@ -48,6 +50,17 @@ export class MonoTaskNoteSettingTab extends PluginSettingTab {
 						}).open();
 					});
 			});
+
+		new Setting(containerEl)
+			.setName('Done Timestamp Format')
+			.setDesc('Format for the done_at timestamp (uses moment.js format). Default: YYYY-MM-DDTHH:mm:ssZ')
+			.addText(text => text
+				.setPlaceholder('YYYY-MM-DDTHH:mm:ssZ')
+				.setValue(this.plugin.settings.doneAtFormat)
+				.onChange(async (value) => {
+					this.plugin.settings.doneAtFormat = value;
+					await this.plugin.saveSettings();
+				}));
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add automatic `done_at` timestamp when task is marked as done
- Configurable timestamp format in plugin settings
- Default format: `YYYY-MM-DDTHH:mm:ssZ`

## Changes
- Added metadata change listener to monitor frontmatter changes
- Automatically adds `done_at` field when `done` is set to `true`
- Added `doneAtFormat` setting with empty default (uses `YYYY-MM-DDTHH:mm:ssZ` if not configured)
- Added settings UI for customizing the timestamp format

## Test Plan
1. Create a new task note
2. Change `done: false` to `done: true` in the frontmatter
3. Verify that `done_at` timestamp is automatically added
4. Test custom format in settings
5. Verify that changing `done` back to `false` doesn't remove the timestamp
6. Verify that if `done_at` already exists, it won't be overwritten

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically adds a done_at timestamp when a Markdown note’s frontmatter has done: true and no existing done_at.
  - Responds to metadata changes, ensuring the timestamp is applied promptly after completion is marked.
  - Adds a “Done Timestamp Format” setting to customize the timestamp (moment.js format), with a default ISO 8601 style (YYYY-MM-DDTHH:mm:ssZ).
  - Setting is editable in the plugin options and is saved for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->