### PR TITLE
docs: add done_at timestamp feature to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ An Obsidian plugin for managing tasks by adding metadata (frontmatter) to notes.
     - `{{date:FORMAT}}`: Custom date format (e.g., `{{date:YYYY/MM/DD}}`)
     - `{{time:FORMAT}}`: Custom time format (e.g., `{{time:HH:mm:ss}}`)
 
+- **Automatic done_at timestamp**: Automatically adds completion timestamp when task is marked as done
+  - When `done` is changed to `true`, automatically adds `done_at` field
+  - Configurable timestamp format in plugin settings
+  - Default format: `YYYY-MM-DDTHH:mm:ssZ` (ISO 8601)
+  - Uses moment.js format strings for customization
+
 ## Installation
 
 1. Copy `main.js`, `styles.css`, and `manifest.json` to your vault `VaultFolder/.obsidian/plugins/mono-task-note/`


### PR DESCRIPTION
## Summary
- Update README.md to document the new done_at timestamp feature

## Changes
- Added documentation for automatic done_at timestamp functionality
- Explained configurable timestamp format in plugin settings
- Documented default ISO 8601 format
- Mentioned moment.js format string support for customization

## Related
- Follows PR #7 which implemented the done_at timestamp feature

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added README guidance on the automatic done_at timestamp when marking tasks as done. Explains the default ISO 8601 format (YYYY-MM-DDTHH:mm:ssZ), how to change the format in settings, and that standard moment-style format strings are supported. No functional changes—this update helps users understand and configure timestamp behavior. Provides clear instructions for customizing formatting to match personal or organizational preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->