### PR TITLE
Add task completion commands and refactor task management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ An Obsidian plugin for managing tasks by adding metadata (frontmatter) to notes.
 
 - **Automatic done_at timestamp**: Automatically adds completion timestamp when task is marked as done
   - When `done` is changed to `true`, automatically adds `done_at` field
+  - When `done` is changed to `false`, automatically removes `done_at` field
   - Configurable timestamp format in plugin settings
   - Default format: `YYYY-MM-DDTHH:mm:ssZ` (ISO 8601)
   - Uses moment.js format strings for customization
+  - Updates `done_at` if it's null, undefined, or empty when marking as complete
+
+- **Task completion commands**: Quick commands to manage task completion status (only works with `type: task` notes)
+  - **Complete current task**: Marks the active task as done and adds/updates `done_at` timestamp
+  - **Uncomplete current task**: Marks the task as incomplete and removes `done_at`
+  - **Toggle task completion**: Quickly switch between done/undone states
 
 ## Installation
 

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { Plugin, Notice, moment, TFile } from 'obsidian';
-import { MonoTaskNoteSettings, DEFAULT_SETTINGS, MonoTaskNoteSettingTab } from './settings';
+import { MonoTaskNoteSettings, DEFAULT_SETTINGS, MonoTaskNoteSettingTab } from './src/settings';
 import { TaskManager } from './src/taskManager';
 
 export default class MonoTaskNotePlugin extends Plugin {
@@ -25,7 +25,12 @@ export default class MonoTaskNotePlugin extends Plugin {
 				const activeFile = this.app.workspace.getActiveFile();
 				if (activeFile && activeFile.extension === 'md') {
 					if (!checking) {
-						this.taskManager.completeTask(activeFile);
+						void this.taskManager
+							.completeTask(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to complete task: ${msg}`);
+							});
 					}
 					return true;
 				}
@@ -40,7 +45,12 @@ export default class MonoTaskNotePlugin extends Plugin {
 				const activeFile = this.app.workspace.getActiveFile();
 				if (activeFile && activeFile.extension === 'md') {
 					if (!checking) {
-						this.taskManager.uncompleteTask(activeFile);
+						void this.taskManager
+							.uncompleteTask(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to uncomplete task: ${msg}`);
+							});
 					}
 					return true;
 				}
@@ -55,7 +65,12 @@ export default class MonoTaskNotePlugin extends Plugin {
 				const activeFile = this.app.workspace.getActiveFile();
 				if (activeFile && activeFile.extension === 'md') {
 					if (!checking) {
-						this.taskManager.toggleTaskCompletion(activeFile);
+						void this.taskManager
+							.toggleTaskCompletion(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to toggle task: ${msg}`);
+							});
 					}
 					return true;
 				}
@@ -158,7 +173,12 @@ export default class MonoTaskNotePlugin extends Plugin {
 		// Only process markdown files
 		if (file.extension !== 'md') return;
 		
-		// Delegate to TaskManager
-		await this.taskManager.handleDoneStatusChange(file);
+		// Delegate to TaskManager with error handling
+		try {
+			await this.taskManager.handleDoneStatusChange(file);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			new Notice(`Failed to update done_at: ${msg}`);
+		}
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, TFile, FuzzySuggestModal } from 'obsidian';
-import type MonoTaskNotePlugin from './main';
+import type MonoTaskNotePlugin from '../main';
 
 export interface MonoTaskNoteSettings {
 	templatePath: string;

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -1,20 +1,54 @@
 import { App, TFile, moment } from 'obsidian';
-import { MonoTaskNoteSettings } from '../settings';
+import { MonoTaskNoteSettings } from './settings';
 
 export class TaskManager {
     constructor(
-        private app: App,
-        private settings: MonoTaskNoteSettings
+        private readonly app: App,
+        private readonly settings: MonoTaskNoteSettings
     ) {}
+
+    /**
+     * Get the current timestamp in the configured format
+     */
+    private formatNow(): string {
+        const format = this.settings.doneAtFormat || 'YYYY-MM-DDTHH:mm:ssZ';
+        return moment().format(format);
+    }
+
+    /**
+     * Check if the file is a task note (has type: task in frontmatter)
+     */
+    private async isTaskNote(file: TFile): Promise<boolean> {
+        const metadata = this.app.metadataCache.getFileCache(file);
+        if (!metadata || !metadata.frontmatter) {
+            return false;
+        }
+        return metadata.frontmatter.type === 'task';
+    }
+
+    /**
+     * Check if done_at field needs to be updated
+     * Returns true if done_at is null, undefined, or empty string
+     */
+    private needsDoneAtUpdate(doneAt: unknown): boolean {
+        return doneAt === null || doneAt === undefined || doneAt === '';
+    }
 
     /**
      * Mark a task as complete by setting done: true and adding done_at timestamp
      */
     async completeTask(file: TFile): Promise<void> {
+        // Check if this is a task note
+        if (!await this.isTaskNote(file)) {
+            return;
+        }
+
         await this.app.fileManager.processFrontMatter(file, (fm) => {
             fm.done = true;
-            const format = this.settings.doneAtFormat || 'YYYY-MM-DDTHH:mm:ssZ';
-            fm.done_at = moment().format(format);
+            // Update done_at if it's null, undefined, or empty
+            if (this.needsDoneAtUpdate(fm.done_at)) {
+                fm.done_at = this.formatNow();
+            }
         });
     }
 
@@ -22,6 +56,11 @@ export class TaskManager {
      * Mark a task as incomplete by setting done: false and removing done_at
      */
     async uncompleteTask(file: TFile): Promise<void> {
+        // Check if this is a task note
+        if (!await this.isTaskNote(file)) {
+            return;
+        }
+
         await this.app.fileManager.processFrontMatter(file, (fm) => {
             fm.done = false;
             delete fm.done_at;
@@ -29,26 +68,34 @@ export class TaskManager {
     }
 
     /**
-     * Toggle task completion status
+     * Toggle task completion status (atomic operation)
      */
     async toggleTaskCompletion(file: TFile): Promise<void> {
+        // Check if this is a task note before processing
         const metadata = this.app.metadataCache.getFileCache(file);
-        if (!metadata || !metadata.frontmatter) {
-            // If no frontmatter exists, mark as complete
-            await this.completeTask(file);
+        if (!metadata || !metadata.frontmatter || metadata.frontmatter.type !== 'task') {
             return;
         }
 
-        const isDone = metadata.frontmatter.done === true;
-        if (isDone) {
-            await this.uncompleteTask(file);
-        } else {
-            await this.completeTask(file);
-        }
+        await this.app.fileManager.processFrontMatter(file, (fm) => {
+            const wasDone = fm.done === true;
+            fm.done = !wasDone;
+            
+            if (fm.done) {
+                // Mark as complete - update done_at if needed
+                if (this.needsDoneAtUpdate(fm.done_at)) {
+                    fm.done_at = this.formatNow();
+                }
+            } else {
+                // Mark as incomplete - remove done_at
+                delete fm.done_at;
+            }
+        });
     }
 
     /**
      * Handle automatic done_at timestamp when done is set to true
+     * Also removes done_at when done is set to false
      */
     async handleDoneStatusChange(file: TFile): Promise<void> {
         const metadata = this.app.metadataCache.getFileCache(file);
@@ -56,11 +103,19 @@ export class TaskManager {
 
         const frontmatter = metadata.frontmatter;
         
-        // Check if done is true and done_at doesn't exist
-        if (frontmatter.done === true && !frontmatter.done_at) {
+        // Only process task notes
+        if (frontmatter.type !== 'task') return;
+        
+        // Check if done is true and done_at doesn't exist or is empty
+        if (frontmatter.done === true && this.needsDoneAtUpdate(frontmatter.done_at)) {
             await this.app.fileManager.processFrontMatter(file, (fm) => {
-                const format = this.settings.doneAtFormat || 'YYYY-MM-DDTHH:mm:ssZ';
-                fm.done_at = moment().format(format);
+                fm.done_at = this.formatNow();
+            });
+        } 
+        // Remove done_at if done is false but done_at exists
+        else if (frontmatter.done !== true && frontmatter.done_at) {
+            await this.app.fileManager.processFrontMatter(file, (fm) => {
+                delete fm.done_at;
             });
         }
     }

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -1,0 +1,67 @@
+import { App, TFile, moment } from 'obsidian';
+import { MonoTaskNoteSettings } from '../settings';
+
+export class TaskManager {
+    constructor(
+        private app: App,
+        private settings: MonoTaskNoteSettings
+    ) {}
+
+    /**
+     * Mark a task as complete by setting done: true and adding done_at timestamp
+     */
+    async completeTask(file: TFile): Promise<void> {
+        await this.app.fileManager.processFrontMatter(file, (fm) => {
+            fm.done = true;
+            const format = this.settings.doneAtFormat || 'YYYY-MM-DDTHH:mm:ssZ';
+            fm.done_at = moment().format(format);
+        });
+    }
+
+    /**
+     * Mark a task as incomplete by setting done: false and removing done_at
+     */
+    async uncompleteTask(file: TFile): Promise<void> {
+        await this.app.fileManager.processFrontMatter(file, (fm) => {
+            fm.done = false;
+            delete fm.done_at;
+        });
+    }
+
+    /**
+     * Toggle task completion status
+     */
+    async toggleTaskCompletion(file: TFile): Promise<void> {
+        const metadata = this.app.metadataCache.getFileCache(file);
+        if (!metadata || !metadata.frontmatter) {
+            // If no frontmatter exists, mark as complete
+            await this.completeTask(file);
+            return;
+        }
+
+        const isDone = metadata.frontmatter.done === true;
+        if (isDone) {
+            await this.uncompleteTask(file);
+        } else {
+            await this.completeTask(file);
+        }
+    }
+
+    /**
+     * Handle automatic done_at timestamp when done is set to true
+     */
+    async handleDoneStatusChange(file: TFile): Promise<void> {
+        const metadata = this.app.metadataCache.getFileCache(file);
+        if (!metadata || !metadata.frontmatter) return;
+
+        const frontmatter = metadata.frontmatter;
+        
+        // Check if done is true and done_at doesn't exist
+        if (frontmatter.done === true && !frontmatter.done_at) {
+            await this.app.fileManager.processFrontMatter(file, (fm) => {
+                const format = this.settings.doneAtFormat || 'YYYY-MM-DDTHH:mm:ssZ';
+                fm.done_at = moment().format(format);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added three new commands for managing task completion status
- Refactored task management logic into a separate module for better code organization
- Improved code maintainability by eliminating duplication

## Changes
- **New Commands**:
  - `Complete current task`: Marks the active task as done with a timestamp
  - `Uncomplete current task`: Marks the task as incomplete and removes the timestamp
  - `Toggle task completion`: Quickly toggle between done/undone states
  
- **Code Organization**:
  - Created `TaskManager` class in `src/taskManager.ts` to handle all task-related operations
  - Moved existing done_at timestamp logic from main.ts to TaskManager
  - Reused common logic across all commands

## Test Plan
- [ ] Test "Complete current task" command on an incomplete task
- [ ] Test "Uncomplete current task" command on a completed task
- [ ] Test "Toggle task completion" command in both states
- [ ] Verify done_at timestamp is added when marking as complete
- [ ] Verify done_at timestamp is removed when marking as incomplete
- [ ] Verify existing automatic done_at addition still works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to complete, uncomplete, and toggle the active task note.
  * Exposes a task manager to handle task operations and timestamps.

* **Bug Fixes**
  * Ensures done_at is added when marking complete and removed when uncompleted; reports failures to the user.

* **Documentation**
  * Added “Task completion commands” docs and behavior for done_at handling.

* **Refactor**
  * Centralized task status logic for consistent behavior across notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->