### PR TITLE
refactor: move main.ts to src directory

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -15,7 +15,7 @@ const context = await esbuild.context({
 	banner: {
 		js: banner,
 	},
-	entryPoints: ["main.ts"],
+	entryPoints: ["src/main.ts"],
 	bundle: true,
 	external: [
 		"obsidian",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { Plugin, Notice, moment, TFile } from 'obsidian';
-import { MonoTaskNoteSettings, DEFAULT_SETTINGS, MonoTaskNoteSettingTab } from './src/settings';
-import { TaskManager } from './src/taskManager';
+import { MonoTaskNoteSettings, DEFAULT_SETTINGS, MonoTaskNoteSettingTab } from './settings';
+import { TaskManager } from './taskManager';
 
-import { TaskFrontmatter } from './src/types';
+import { TaskFrontmatter } from './types';
 
 export default class MonoTaskNotePlugin extends Plugin {
 	settings: MonoTaskNoteSettings;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, TFile, FuzzySuggestModal } from 'obsidian';
-import type MonoTaskNotePlugin from '../main';
+import type MonoTaskNotePlugin from './main';
 
 export interface MonoTaskNoteSettings {
 	templatePath: string;


### PR DESCRIPTION
## Summary
- Moved `main.ts` to `src/main.ts` for better project organization
- Updated all related import paths
- Updated esbuild configuration

## Changes
- Moved `main.ts` → `src/main.ts`
- Updated import path in `src/settings.ts`
- Updated entry point in `esbuild.config.mjs`

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] TypeScript type checking passes (`npx tsc -noEmit -skipLibCheck`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal module import paths and corrected a type-only import for consistent module resolution. No user-visible impact.
* **Chores**
  * Updated build configuration to point to the correct entry file while preserving existing production and watch behaviors. No changes to functionality or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->