### PR TITLE
feat: add configurable task note directory

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,7 +104,7 @@ class TemplateSearchModal extends FuzzySuggestModal<TFile> {
 		const files = this.app.vault.getMarkdownFiles();
 		return files.filter(file => {
 			const path = file.path.toLowerCase();
-			return path.includes('template') || path.includes('テンプレート');
+			return path.includes('template');
 		});
 	}
 
@@ -129,7 +129,7 @@ class FolderSearchModal extends FuzzySuggestModal<TFolder> {
 		const folders: TFolder[] = [];
 		const rootFolder = this.app.vault.getRoot();
 		
-		const collectFolders = (folder: TFolder) => {
+		const collectFolders = (folder: TFolder): void => {
 			folders.push(folder);
 			for (const child of folder.children) {
 				if (child instanceof TFolder) {
@@ -139,7 +139,9 @@ class FolderSearchModal extends FuzzySuggestModal<TFolder> {
 		};
 		
 		collectFolders(rootFolder);
-		return folders;
+		return folders
+			.filter(f => f.path !== '.obsidian')
+			.sort((a, b) => a.path.localeCompare(b.path));
 	}
 
 	getItemText(folder: TFolder): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,14 +1,16 @@
-import { App, PluginSettingTab, Setting, TFile, FuzzySuggestModal } from 'obsidian';
+import { App, PluginSettingTab, Setting, TFile, TFolder, FuzzySuggestModal } from 'obsidian';
 import type MonoTaskNotePlugin from './main';
 
 export interface MonoTaskNoteSettings {
 	templatePath: string;
 	doneAtFormat: string;
+	taskNoteDirectory: string;
 }
 
 export const DEFAULT_SETTINGS: MonoTaskNoteSettings = {
 	templatePath: '',
-	doneAtFormat: ''
+	doneAtFormat: '',
+	taskNoteDirectory: ''
 };
 
 export class MonoTaskNoteSettingTab extends PluginSettingTab {
@@ -52,6 +54,32 @@ export class MonoTaskNoteSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName('Task Note Directory')
+			.setDesc('Select the directory where task notes will be created')
+			.addText(text => {
+				text
+					.setPlaceholder('Directory path (leave empty for vault root)')
+					.setValue(this.plugin.settings.taskNoteDirectory)
+					.onChange(async (value) => {
+						this.plugin.settings.taskNoteDirectory = value;
+						await this.plugin.saveSettings();
+					});
+				
+				text.inputEl.style.width = '300px';
+			})
+			.addButton(button => {
+				button
+					.setButtonText('Select')
+					.onClick(() => {
+						new FolderSearchModal(this.app, async (folder: TFolder) => {
+							this.plugin.settings.taskNoteDirectory = folder.path;
+							await this.plugin.saveSettings();
+							this.display();
+						}).open();
+					});
+			});
+
+		new Setting(containerEl)
 			.setName('Done Timestamp Format')
 			.setDesc('Format for the done_at timestamp (uses moment.js format). Default: YYYY-MM-DDTHH:mm:ssZ')
 			.addText(text => text
@@ -86,5 +114,39 @@ class TemplateSearchModal extends FuzzySuggestModal<TFile> {
 
 	onChooseItem(file: TFile): void {
 		this.onChoose(file);
+	}
+}
+
+class FolderSearchModal extends FuzzySuggestModal<TFolder> {
+	onChoose: (folder: TFolder) => void;
+
+	constructor(app: App, onChoose: (folder: TFolder) => void) {
+		super(app);
+		this.onChoose = onChoose;
+	}
+
+	getItems(): TFolder[] {
+		const folders: TFolder[] = [];
+		const rootFolder = this.app.vault.getRoot();
+		
+		const collectFolders = (folder: TFolder) => {
+			folders.push(folder);
+			for (const child of folder.children) {
+				if (child instanceof TFolder) {
+					collectFolders(child);
+				}
+			}
+		};
+		
+		collectFolders(rootFolder);
+		return folders;
+	}
+
+	getItemText(folder: TFolder): string {
+		return folder.path || '/';
+	}
+
+	onChooseItem(folder: TFolder): void {
+		this.onChoose(folder);
 	}
 }


### PR DESCRIPTION
## Summary
- Add ability to configure task note save directory via settings
- Implement directory picker UI for easy selection from settings screen
- Auto-create directory if it doesn't exist

## Changes
- Add `taskNoteDirectory` property to `MonoTaskNoteSettings` interface
- Add "Task Note Directory" setting with text input and directory picker button
- Implement `FolderSearchModal` class (follows existing `TemplateSearchModal` UI design)
- Update `createTaskNote` method to create files in configured directory
- Falls back to vault root when directory is not specified (backward compatible)

## Test plan
- [x] Directory picker works correctly in settings screen
- [x] Task notes are created in selected directory
- [x] Directory path can be entered directly via text input
- [x] Non-existent directories are auto-created when specified
- [x] Empty setting defaults to vault root (backward compatibility)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Task Note Directory setting with a folder picker to choose where new task notes are created (vault root by default).
  - All new task notes (template-based or default) are created in the chosen directory; note opens after creation and title is focused for quick renaming.
  - Creation notice now shows the note’s filename (basename) instead of a timestamp.

- **Bug Fixes**
  - Folder creation failures are safely ignored to avoid interruptions.
  - Template search narrowed to matching template paths only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->