### PR TITLE
refactor: modularize main.ts for better maintainability

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,98 @@
+import { Plugin, Notice } from 'obsidian';
+import { TaskManager } from './taskManager';
+import { TaskNoteCreator } from './taskNoteCreator';
+
+export class CommandManager {
+	private plugin: Plugin;
+	private taskManager: TaskManager;
+	private taskNoteCreator: TaskNoteCreator;
+
+	constructor(plugin: Plugin, taskManager: TaskManager, taskNoteCreator: TaskNoteCreator) {
+		this.plugin = plugin;
+		this.taskManager = taskManager;
+		this.taskNoteCreator = taskNoteCreator;
+	}
+
+	registerCommands(): void {
+		this.registerCreateTaskNoteCommand();
+		this.registerCompleteTaskCommand();
+		this.registerUncompleteTaskCommand();
+		this.registerToggleTaskCommand();
+	}
+
+	private registerCreateTaskNoteCommand(): void {
+		this.plugin.addCommand({
+			id: 'create-task-note',
+			name: 'Create task note',
+			callback: async () => {
+				await this.taskNoteCreator.createTaskNote();
+			}
+		});
+	}
+
+	private registerCompleteTaskCommand(): void {
+		this.plugin.addCommand({
+			id: 'complete-current-task',
+			name: 'Complete current task',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.completeTask(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to complete task: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+
+	private registerUncompleteTaskCommand(): void {
+		this.plugin.addCommand({
+			id: 'uncomplete-current-task',
+			name: 'Uncomplete current task',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.uncompleteTask(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to uncomplete task: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+
+	private registerToggleTaskCommand(): void {
+		this.plugin.addCommand({
+			id: 'toggle-task-completion',
+			name: 'Toggle task completion',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.toggleTaskCompletion(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to toggle task: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,92 +1,27 @@
-import { Plugin, Notice, moment, TFile } from 'obsidian';
+import { Plugin, Notice, TFile } from 'obsidian';
 import { MonoTaskNoteSettings, DEFAULT_SETTINGS, MonoTaskNoteSettingTab } from './settings';
 import { TaskManager } from './taskManager';
-
-import { TaskFrontmatter, Commands } from './types';
-
-// Extend the App interface to include commands
-declare module 'obsidian' {
-    interface App {
-        commands: Commands;
-    }
-}
+import { CommandManager } from './commands';
+import { TaskNoteCreator } from './taskNoteCreator';
 
 export default class MonoTaskNotePlugin extends Plugin {
 	settings: MonoTaskNoteSettings;
 	taskManager: TaskManager;
+	commandManager: CommandManager;
+	taskNoteCreator: TaskNoteCreator;
 
 	async onload() {
 		await this.loadSettings();
+		
+		// Initialize managers
 		this.taskManager = new TaskManager(this.app, this.settings);
+		this.taskNoteCreator = new TaskNoteCreator(this.app, this.settings);
+		this.commandManager = new CommandManager(this, this.taskManager, this.taskNoteCreator);
+		
+		// Register commands
+		this.commandManager.registerCommands();
 
-		this.addCommand({
-			id: 'create-task-note',
-			name: 'Create task note',
-			callback: async () => {
-				await this.createTaskNote();
-			}
-		});
-
-		this.addCommand({
-			id: 'complete-current-task',
-			name: 'Complete current task',
-			checkCallback: (checking: boolean) => {
-				const activeFile = this.app.workspace.getActiveFile();
-				if (activeFile && activeFile.extension === 'md') {
-					if (!checking) {
-						void this.taskManager
-							.completeTask(activeFile)
-							.catch((err: unknown) => {
-								const msg = err instanceof Error ? err.message : String(err);
-								new Notice(`Failed to complete task: ${msg}`);
-							});
-					}
-					return true;
-				}
-				return false;
-			}
-		});
-
-		this.addCommand({
-			id: 'uncomplete-current-task',
-			name: 'Uncomplete current task',
-			checkCallback: (checking: boolean) => {
-				const activeFile = this.app.workspace.getActiveFile();
-				if (activeFile && activeFile.extension === 'md') {
-					if (!checking) {
-						void this.taskManager
-							.uncompleteTask(activeFile)
-							.catch((err: unknown) => {
-								const msg = err instanceof Error ? err.message : String(err);
-								new Notice(`Failed to uncomplete task: ${msg}`);
-							});
-					}
-					return true;
-				}
-				return false;
-			}
-		});
-
-		this.addCommand({
-			id: 'toggle-task-completion',
-			name: 'Toggle task completion',
-			checkCallback: (checking: boolean) => {
-				const activeFile = this.app.workspace.getActiveFile();
-				if (activeFile && activeFile.extension === 'md') {
-					if (!checking) {
-						void this.taskManager
-							.toggleTaskCompletion(activeFile)
-							.catch((err: unknown) => {
-								const msg = err instanceof Error ? err.message : String(err);
-								new Notice(`Failed to toggle task: ${msg}`);
-							});
-					}
-					return true;
-				}
-				return false;
-			}
-		});
-
+		// Add settings tab
 		this.addSettingTab(new MonoTaskNoteSettingTab(this.app, this));
 
 		// Register metadata change event
@@ -105,113 +40,7 @@ export default class MonoTaskNotePlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	async createTaskNote() {
-		const timestamp = moment().unix();
-		const fileName = `${timestamp}.md`;
-		
-		// Construct the full path with directory if specified
-		let filePath = fileName;
-		if (this.settings.taskNoteDirectory) {
-			// Normalize the directory path (remove trailing slashes)
-			const normalizedDir = this.settings.taskNoteDirectory.replace(/\/+$/, '');
-			
-			// Ensure the directory exists
-			const folder = this.app.vault.getAbstractFileByPath(normalizedDir);
-			if (!folder) {
-				try {
-					await this.app.vault.createFolder(normalizedDir);
-				} catch (error) {
-					// Only show error if it's not about the folder already existing
-					if (error instanceof Error && !error.message.includes('already exists')) {
-						new Notice(`Failed to create directory: ${error.message}`);
-						// Fall back to root directory
-						filePath = fileName;
-					}
-				}
-			}
-			
-			// Only use the directory if we confirmed it exists or created it successfully
-			if (filePath !== fileName || folder) {
-				filePath = normalizedDir ? `${normalizedDir}/${fileName}` : fileName;
-			}
-		}
-		
-		try {
-			let file: TFile;
-			
-			if (this.settings.templatePath) {
-				const templateFile = this.app.vault.getAbstractFileByPath(this.settings.templatePath);
-				
-				if (templateFile instanceof TFile) {
-					const templateContent = await this.app.vault.read(templateFile);
-					const processedContent = this.processTemplateVariables(templateContent, fileName);
-					file = await this.app.vault.create(filePath, processedContent);
-				} else {
-					file = await this.createDefaultTaskNote(filePath);
-				}
-			} else {
-				file = await this.createDefaultTaskNote(filePath);
-			}
-			
-			await this.app.fileManager.processFrontMatter(file, (frontmatter: Partial<TaskFrontmatter>) => {
-				frontmatter.done ??= false;
-				frontmatter.due_date ??= null;
-				frontmatter.priority ??= 4;
-				frontmatter.scheduled_time ??= null;
-				frontmatter.type ??= 'task';
-			});
-			
-			new Notice(`Task note created: ${file.basename}`);
-			
-			const leaf = this.app.workspace.getLeaf(false);
-			await leaf.openFile(file);
-			
-			// Trigger rename command to focus on filename input
-			setTimeout(() => {
-				this.app.commands.executeCommandById('workspace:edit-file-title');
-			}, 100);
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : String(err);
-			new Notice(`Failed to create task note: ${msg}`);
-		}
-	}
-
-	async createDefaultTaskNote(filePath: string): Promise<TFile> {
-		const content = '';
-		return this.app.vault.create(filePath, content);
-	}
-
-	processTemplateVariables(content: string, fileName: string): string {
-		const now = moment();
-		
-		let processedContent = content;
-		
-		// Default replacements
-		processedContent = processedContent.replace(/\{\{date\}\}/g, now.format('YYYY-MM-DD'));
-		processedContent = processedContent.replace(/\{\{time\}\}/g, now.format('HH:mm'));
-		processedContent = processedContent.replace(/\{\{title\}\}/g, fileName.replace('.md', ''));
-		
-		// Custom format replacements - directly pass format to moment
-		processedContent = processedContent.replace(/\{\{date:([^}]+)\}\}/g, (match, format) => {
-			try {
-				return now.format(format);
-			} catch {
-				return match;
-			}
-		});
-		
-		processedContent = processedContent.replace(/\{\{time:([^}]+)\}\}/g, (match, format) => {
-			try {
-				return now.format(format);
-			} catch {
-				return match;
-			}
-		});
-		
-		return processedContent;
-	}
-
-	async handleMetadataChange(file: TFile) {
+	private async handleMetadataChange(file: TFile) {
 		// Only process markdown files
 		if (file.extension !== 'md') return;
 		

--- a/src/taskNoteCreator.ts
+++ b/src/taskNoteCreator.ts
@@ -1,0 +1,115 @@
+import { App, Notice, moment, TFile } from 'obsidian';
+import { MonoTaskNoteSettings } from './settings';
+import { TaskFrontmatter, Commands } from './types';
+import { TemplateProcessor } from './templateProcessor';
+
+declare module 'obsidian' {
+	interface App {
+		commands: Commands;
+	}
+}
+
+export class TaskNoteCreator {
+	private app: App;
+	private settings: MonoTaskNoteSettings;
+	private templateProcessor: TemplateProcessor;
+
+	constructor(app: App, settings: MonoTaskNoteSettings) {
+		this.app = app;
+		this.settings = settings;
+		this.templateProcessor = new TemplateProcessor();
+	}
+
+	async createTaskNote(): Promise<void> {
+		const timestamp = moment().unix();
+		const fileName = `${timestamp}.md`;
+		
+		const filePath = this.getFilePath(fileName);
+		
+		try {
+			const file = await this.createFile(filePath, fileName);
+			await this.initializeFrontmatter(file);
+			
+			new Notice(`Task note created: ${file.basename}`);
+			
+			await this.openAndFocusFile(file);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			new Notice(`Failed to create task note: ${msg}`);
+		}
+	}
+
+	private getFilePath(fileName: string): string {
+		if (!this.settings.taskNoteDirectory) {
+			return fileName;
+		}
+
+		const normalizedDir = this.settings.taskNoteDirectory.replace(/\/+$/, '');
+		return normalizedDir ? `${normalizedDir}/${fileName}` : fileName;
+	}
+
+	private async createFile(filePath: string, fileName: string): Promise<TFile> {
+		await this.ensureDirectoryExists();
+
+		if (this.settings.templatePath) {
+			return await this.createFromTemplate(filePath, fileName);
+		}
+		
+		return await this.createDefaultTaskNote(filePath);
+	}
+
+	private async ensureDirectoryExists(): Promise<void> {
+		if (!this.settings.taskNoteDirectory) {
+			return;
+		}
+
+		const normalizedDir = this.settings.taskNoteDirectory.replace(/\/+$/, '');
+		const folder = this.app.vault.getAbstractFileByPath(normalizedDir);
+		
+		if (!folder) {
+			try {
+				await this.app.vault.createFolder(normalizedDir);
+			} catch (error) {
+				if (error instanceof Error && !error.message.includes('already exists')) {
+					throw error;
+				}
+			}
+		}
+	}
+
+	private async createFromTemplate(filePath: string, fileName: string): Promise<TFile> {
+		const templateFile = this.app.vault.getAbstractFileByPath(this.settings.templatePath);
+		
+		if (!(templateFile instanceof TFile)) {
+			return await this.createDefaultTaskNote(filePath);
+		}
+
+		const templateContent = await this.app.vault.read(templateFile);
+		const processedContent = this.templateProcessor.processTemplateVariables(templateContent, fileName);
+		return await this.app.vault.create(filePath, processedContent);
+	}
+
+	private async createDefaultTaskNote(filePath: string): Promise<TFile> {
+		const content = '';
+		return this.app.vault.create(filePath, content);
+	}
+
+	private async initializeFrontmatter(file: TFile): Promise<void> {
+		await this.app.fileManager.processFrontMatter(file, (frontmatter: Partial<TaskFrontmatter>) => {
+			frontmatter.done ??= false;
+			frontmatter.due_date ??= null;
+			frontmatter.priority ??= 4;
+			frontmatter.scheduled_time ??= null;
+			frontmatter.type ??= 'task';
+		});
+	}
+
+	private async openAndFocusFile(file: TFile): Promise<void> {
+		const leaf = this.app.workspace.getLeaf(false);
+		await leaf.openFile(file);
+		
+		setTimeout(() => {
+			this.app.commands.executeCommandById('workspace:edit-file-title');
+		}, 100);
+	}
+}

--- a/src/templateProcessor.ts
+++ b/src/templateProcessor.ts
@@ -1,0 +1,33 @@
+import { moment } from 'obsidian';
+
+export class TemplateProcessor {
+	processTemplateVariables(content: string, fileName: string): string {
+		const now = moment();
+		
+		let processedContent = content;
+		
+		// Default replacements
+		processedContent = processedContent.replace(/\{\{date\}\}/g, now.format('YYYY-MM-DD'));
+		processedContent = processedContent.replace(/\{\{time\}\}/g, now.format('HH:mm'));
+		processedContent = processedContent.replace(/\{\{title\}\}/g, fileName.replace('.md', ''));
+		
+		// Custom format replacements - directly pass format to moment
+		processedContent = processedContent.replace(/\{\{date:([^}]+)\}\}/g, (match, format) => {
+			try {
+				return now.format(format);
+			} catch {
+				return match;
+			}
+		});
+		
+		processedContent = processedContent.replace(/\{\{time:([^}]+)\}\}/g, (match, format) => {
+			try {
+				return now.format(format);
+			} catch {
+				return match;
+			}
+		});
+		
+		return processedContent;
+	}
+}


### PR DESCRIPTION
## Summary
- Split main.ts into smaller, focused modules to improve maintainability
- Reduced main.ts from 226 lines to 55 lines
- Improved code organization following single responsibility principle

## Changes
- **CommandManager** (`src/commands.ts`): Handles all command registrations
- **TaskNoteCreator** (`src/taskNoteCreator.ts`): Manages task note creation logic  
- **TemplateProcessor** (`src/templateProcessor.ts`): Processes template variables
- **main.ts**: Now only handles plugin initialization and manager coordination

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes without errors
- [x] Build completes successfully
- [x] Manual testing: Create task note
- [x] Manual testing: Complete/uncomplete/toggle task commands
- [x] Manual testing: Template processing works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added commands to create a task note and to complete/uncomplete/toggle the current task. Commands are available only in Markdown files and show clear in-app notices on errors.
  * Introduced task note creation with optional template support, including placeholders for date, time, and title. Notes open immediately and focus the title for quick renaming.
  * Added a settings tab to configure task note directory and template path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->