### PR TITLE
feat: use 13-digit millisecond timestamp for task note filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mono Task Note treats each note as a single task, automatically managing task me
 
 ### Task Creation
 - **Create task note command**: Instantly create a new task note with predefined frontmatter
-  - Filename: Unix timestamp (e.g., `1734567890.md`)
+  - Filename: 13-digit Unix timestamp in milliseconds (e.g., `1734567890123.md`)
   - Task frontmatter fields:
     - `type`: task (identifies the note as a task)
     - `done`: false (completion status)

--- a/src/taskNoteCreator.ts
+++ b/src/taskNoteCreator.ts
@@ -21,7 +21,7 @@ export class TaskNoteCreator {
 	}
 
 	async createTaskNote(): Promise<void> {
-		const timestamp = moment().unix();
+		const timestamp = moment().format('x');
 		const fileName = `${timestamp}.md`;
 		
 		const filePath = this.getFilePath(fileName);


### PR DESCRIPTION
## Summary
- Changed task note filename generation from 10-digit Unix timestamp (seconds) to 13-digit timestamp (milliseconds)
- Provides better precision and uniqueness for task note filenames

## Changes
- Updated `taskNoteCreator.ts` to use `moment().format('x')` instead of `moment().unix()`
- Updated README documentation to reflect the new filename format

## Test plan
- [ ] Create a new task note and verify it uses 13-digit timestamp
- [ ] Verify the filename format is like `1734567890123.md`
- [ ] Confirm all existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task note filenames now use millisecond-precision timestamps, significantly reducing the chance of duplicate filenames created within the same second. Existing files are unaffected; new notes will display a 13-digit timestamp. No behavior changes to note creation beyond filename format.

* **Documentation**
  * Updated the README task creation example to reflect the new millisecond timestamp filename format, ensuring examples match current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->