### PR TITLE
feat: add recurring tasks functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Mono Task Note treats each note as a single task, automatically managing task me
     - `scheduled_time`: null (scheduled time)
   - Automatically opens the created note for immediate editing
 
+### Recurring Tasks
+- **Create recurring task note command**: Create a task that repeats on a schedule
+  - All standard task fields plus:
+    - `attributes`: ['recurring'] (identifies as recurring task)
+    - `recurringDaysOfMonth`: [] (days of month 1-31)
+    - `recurringDaysOfWeek`: [] (days of week: Mon, Tue, Wed, Thu, Fri, Sat, Sun)
+    - `recurringScheduledTimes`: [] (times in HH:mm format)
+  
+- **Configure recurring schedules**: Interactive modals for setting recurrence patterns
+  - **Set recurring days of month**: Select specific days (1-31) when task should recur
+  - **Set recurring days of week**: Choose weekdays for weekly recurring tasks
+  - **Set recurring scheduled times**: Add multiple scheduled times in HH:mm format
+  - Commands only available for notes with `attributes: ['recurring']`
+
 ### Template System
 - **Custom templates**: Create task notes using your own templates
   - Configure template file path in plugin settings

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,9 +15,13 @@ export class CommandManager {
 
 	registerCommands(): void {
 		this.registerCreateTaskNoteCommand();
+		this.registerCreateRecurringTaskNoteCommand();
 		this.registerCompleteTaskCommand();
 		this.registerUncompleteTaskCommand();
 		this.registerToggleTaskCommand();
+		this.registerSetRecurringDaysOfMonthCommand();
+		this.registerSetRecurringDaysOfWeekCommand();
+		this.registerSetRecurringScheduledTimesCommand();
 	}
 
 	private registerCreateTaskNoteCommand(): void {
@@ -26,6 +30,16 @@ export class CommandManager {
 			name: 'Create task note',
 			callback: async () => {
 				await this.taskNoteCreator.createTaskNote();
+			}
+		});
+	}
+
+	private registerCreateRecurringTaskNoteCommand(): void {
+		this.plugin.addCommand({
+			id: 'create-recurring-task-note',
+			name: 'Create recurring task note',
+			callback: async () => {
+				await this.taskNoteCreator.createRecurringTaskNote();
 			}
 		});
 	}
@@ -87,6 +101,72 @@ export class CommandManager {
 							.catch((err: unknown) => {
 								const msg = err instanceof Error ? err.message : String(err);
 								new Notice(`Failed to toggle task: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+
+	private registerSetRecurringDaysOfMonthCommand(): void {
+		this.plugin.addCommand({
+			id: 'set-recurring-days-of-month',
+			name: 'Set recurring days of month',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.setRecurringDaysOfMonth(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to set recurring days: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+
+	private registerSetRecurringDaysOfWeekCommand(): void {
+		this.plugin.addCommand({
+			id: 'set-recurring-days-of-week',
+			name: 'Set recurring days of week',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.setRecurringDaysOfWeek(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to set recurring days: ${msg}`);
+							});
+					}
+					return true;
+				}
+				return false;
+			}
+		});
+	}
+
+	private registerSetRecurringScheduledTimesCommand(): void {
+		this.plugin.addCommand({
+			id: 'set-recurring-scheduled-times',
+			name: 'Set recurring scheduled times',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (activeFile && activeFile.extension === 'md') {
+					if (!checking) {
+						void this.taskManager
+							.setRecurringScheduledTimes(activeFile)
+							.catch((err: unknown) => {
+								const msg = err instanceof Error ? err.message : String(err);
+								new Notice(`Failed to set recurring times: ${msg}`);
 							});
 					}
 					return true;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,7 +39,13 @@ export class CommandManager {
 			id: 'create-recurring-task-note',
 			name: 'Create recurring task note',
 			callback: async () => {
-				await this.taskNoteCreator.createRecurringTaskNote();
+				try {
+					await this.taskNoteCreator.createRecurringTaskNote();
+				} catch (err: unknown) {
+					const msg = err instanceof Error ? err.message : String(err);
+					console.error('Failed to create recurring task note:', err);
+					new Notice(`Failed to create recurring task note: ${msg}`);
+				}
 			}
 		});
 	}

--- a/src/modals/DaysOfMonthPickerModal.ts
+++ b/src/modals/DaysOfMonthPickerModal.ts
@@ -1,0 +1,89 @@
+import { App, Modal, ButtonComponent, TFile } from 'obsidian';
+
+export class DaysOfMonthPickerModal extends Modal {
+	private selectedDays: Set<number>;
+	private file: TFile;
+	private onSave: (days: number[]) => void;
+
+	constructor(app: App, file: TFile, currentDays: number[], onSave: (days: number[]) => void) {
+		super(app);
+		this.file = file;
+		this.selectedDays = new Set(currentDays);
+		this.onSave = onSave;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		contentEl.createEl('h2', { text: 'Select Days of Month for Recurring Task' });
+
+		const description = contentEl.createEl('p', { 
+			text: 'Select the days of the month when this task should recur.',
+			cls: 'setting-item-description'
+		});
+		description.style.marginBottom = '1em';
+
+		const daysContainer = contentEl.createDiv({ cls: 'days-grid' });
+		daysContainer.style.display = 'grid';
+		daysContainer.style.gridTemplateColumns = 'repeat(7, 1fr)';
+		daysContainer.style.gap = '8px';
+		daysContainer.style.marginBottom = '1em';
+
+		for (let day = 1; day <= 31; day++) {
+			const dayButton = daysContainer.createEl('button', {
+				text: day.toString(),
+				cls: 'day-button'
+			});
+
+			dayButton.style.padding = '8px';
+			dayButton.style.border = '1px solid var(--background-modifier-border)';
+			dayButton.style.borderRadius = '4px';
+			dayButton.style.cursor = 'pointer';
+			dayButton.style.backgroundColor = this.selectedDays.has(day) 
+				? 'var(--interactive-accent)' 
+				: 'var(--background-secondary)';
+			dayButton.style.color = this.selectedDays.has(day)
+				? 'var(--text-on-accent)'
+				: 'var(--text-normal)';
+
+			dayButton.addEventListener('click', () => {
+				if (this.selectedDays.has(day)) {
+					this.selectedDays.delete(day);
+					dayButton.style.backgroundColor = 'var(--background-secondary)';
+					dayButton.style.color = 'var(--text-normal)';
+				} else {
+					this.selectedDays.add(day);
+					dayButton.style.backgroundColor = 'var(--interactive-accent)';
+					dayButton.style.color = 'var(--text-on-accent)';
+				}
+			});
+		}
+
+		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+		buttonContainer.style.display = 'flex';
+		buttonContainer.style.justifyContent = 'flex-end';
+		buttonContainer.style.gap = '8px';
+		buttonContainer.style.marginTop = '1em';
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Cancel')
+			.onClick(() => {
+				this.close();
+			});
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Save')
+			.setCta()
+			.onClick(() => {
+				const days = Array.from(this.selectedDays).sort((a, b) => a - b);
+				this.onSave(days);
+				this.close();
+			});
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/modals/DaysOfWeekPickerModal.ts
+++ b/src/modals/DaysOfWeekPickerModal.ts
@@ -1,0 +1,114 @@
+import { App, Modal, ButtonComponent, TFile } from 'obsidian';
+
+export class DaysOfWeekPickerModal extends Modal {
+	private selectedDays: Set<string>;
+	private file: TFile;
+	private onSave: (days: string[]) => void;
+	private readonly daysOfWeek = [
+		{ short: 'Mon', full: 'Monday' },
+		{ short: 'Tue', full: 'Tuesday' },
+		{ short: 'Wed', full: 'Wednesday' },
+		{ short: 'Thu', full: 'Thursday' },
+		{ short: 'Fri', full: 'Friday' },
+		{ short: 'Sat', full: 'Saturday' },
+		{ short: 'Sun', full: 'Sunday' }
+	];
+
+	constructor(app: App, file: TFile, currentDays: string[], onSave: (days: string[]) => void) {
+		super(app);
+		this.file = file;
+		this.selectedDays = new Set(currentDays);
+		this.onSave = onSave;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		contentEl.createEl('h2', { text: 'Select Days of Week for Recurring Task' });
+
+		const description = contentEl.createEl('p', { 
+			text: 'Select the days of the week when this task should recur.',
+			cls: 'setting-item-description'
+		});
+		description.style.marginBottom = '1em';
+
+		const daysContainer = contentEl.createDiv({ cls: 'days-container' });
+		daysContainer.style.display = 'flex';
+		daysContainer.style.flexDirection = 'column';
+		daysContainer.style.gap = '8px';
+		daysContainer.style.marginBottom = '1em';
+
+		this.daysOfWeek.forEach(day => {
+			const dayItem = daysContainer.createDiv({ cls: 'day-item' });
+			dayItem.style.display = 'flex';
+			dayItem.style.alignItems = 'center';
+			dayItem.style.padding = '8px';
+			dayItem.style.border = '1px solid var(--background-modifier-border)';
+			dayItem.style.borderRadius = '4px';
+			dayItem.style.cursor = 'pointer';
+			dayItem.style.backgroundColor = this.selectedDays.has(day.short) 
+				? 'var(--interactive-accent)' 
+				: 'var(--background-secondary)';
+			dayItem.style.color = this.selectedDays.has(day.short)
+				? 'var(--text-on-accent)'
+				: 'var(--text-normal)';
+
+			const checkbox = dayItem.createEl('input', { type: 'checkbox' });
+			checkbox.checked = this.selectedDays.has(day.short);
+			checkbox.style.marginRight = '8px';
+
+			const label = dayItem.createEl('span', { text: `${day.full} (${day.short})` });
+			label.style.flex = '1';
+
+			const toggleSelection = () => {
+				if (this.selectedDays.has(day.short)) {
+					this.selectedDays.delete(day.short);
+					checkbox.checked = false;
+					dayItem.style.backgroundColor = 'var(--background-secondary)';
+					dayItem.style.color = 'var(--text-normal)';
+				} else {
+					this.selectedDays.add(day.short);
+					checkbox.checked = true;
+					dayItem.style.backgroundColor = 'var(--interactive-accent)';
+					dayItem.style.color = 'var(--text-on-accent)';
+				}
+			};
+
+			dayItem.addEventListener('click', toggleSelection);
+			checkbox.addEventListener('click', (e) => {
+				e.stopPropagation();
+				toggleSelection();
+			});
+		});
+
+		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+		buttonContainer.style.display = 'flex';
+		buttonContainer.style.justifyContent = 'flex-end';
+		buttonContainer.style.gap = '8px';
+		buttonContainer.style.marginTop = '1em';
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Cancel')
+			.onClick(() => {
+				this.close();
+			});
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Save')
+			.setCta()
+			.onClick(() => {
+				// Preserve the order of days as they appear in the week
+				const orderedDays = this.daysOfWeek
+					.filter(day => this.selectedDays.has(day.short))
+					.map(day => day.short);
+				this.onSave(orderedDays);
+				this.close();
+			});
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/modals/ScheduledTimesPickerModal.ts
+++ b/src/modals/ScheduledTimesPickerModal.ts
@@ -1,0 +1,126 @@
+import { App, Modal, ButtonComponent, TFile, TextComponent, Notice } from 'obsidian';
+
+export class ScheduledTimesPickerModal extends Modal {
+	private scheduledTimes: string[];
+	private file: TFile;
+	private onSave: (times: string[]) => void;
+	private timeInputs: TextComponent[] = [];
+
+	constructor(app: App, file: TFile, currentTimes: string[], onSave: (times: string[]) => void) {
+		super(app);
+		this.file = file;
+		this.scheduledTimes = [...currentTimes];
+		this.onSave = onSave;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		contentEl.createEl('h2', { text: 'Set Recurring Scheduled Times' });
+
+		const description = contentEl.createEl('p', { 
+			text: 'Add scheduled times for this recurring task in HH:mm format (e.g., 09:00, 14:30).',
+			cls: 'setting-item-description'
+		});
+		description.style.marginBottom = '1em';
+
+		const timesContainer = contentEl.createDiv({ cls: 'times-container' });
+		timesContainer.style.display = 'flex';
+		timesContainer.style.flexDirection = 'column';
+		timesContainer.style.gap = '8px';
+		timesContainer.style.marginBottom = '1em';
+
+		const renderTimeInputs = () => {
+			timesContainer.empty();
+			this.timeInputs = [];
+
+			this.scheduledTimes.forEach((time, index) => {
+				const timeItem = timesContainer.createDiv({ cls: 'time-item' });
+				timeItem.style.display = 'flex';
+				timeItem.style.alignItems = 'center';
+				timeItem.style.gap = '8px';
+
+				const timeInput = new TextComponent(timeItem);
+				timeInput.setValue(time);
+				timeInput.setPlaceholder('HH:mm');
+				timeInput.inputEl.style.width = '100px';
+				timeInput.onChange((value) => {
+					this.scheduledTimes[index] = value;
+				});
+				this.timeInputs.push(timeInput);
+
+				new ButtonComponent(timeItem)
+					.setButtonText('Remove')
+					.onClick(() => {
+						this.scheduledTimes.splice(index, 1);
+						renderTimeInputs();
+					});
+			});
+
+			// Add new time input
+			const addTimeItem = timesContainer.createDiv({ cls: 'add-time-item' });
+			addTimeItem.style.display = 'flex';
+			addTimeItem.style.alignItems = 'center';
+			addTimeItem.style.gap = '8px';
+			addTimeItem.style.marginTop = '8px';
+
+			const newTimeInput = new TextComponent(addTimeItem);
+			newTimeInput.setPlaceholder('HH:mm');
+			newTimeInput.inputEl.style.width = '100px';
+
+			new ButtonComponent(addTimeItem)
+				.setButtonText('Add Time')
+				.onClick(() => {
+					const value = newTimeInput.getValue().trim();
+					if (value && this.isValidTimeFormat(value)) {
+						this.scheduledTimes.push(value);
+						renderTimeInputs();
+					} else if (value) {
+						new Notice('Please enter time in HH:mm format (e.g., 09:00, 14:30)');
+					}
+				});
+		};
+
+		renderTimeInputs();
+
+		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+		buttonContainer.style.display = 'flex';
+		buttonContainer.style.justifyContent = 'flex-end';
+		buttonContainer.style.gap = '8px';
+		buttonContainer.style.marginTop = '1em';
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Cancel')
+			.onClick(() => {
+				this.close();
+			});
+
+		new ButtonComponent(buttonContainer)
+			.setButtonText('Save')
+			.setCta()
+			.onClick(() => {
+				const validTimes = this.scheduledTimes
+					.filter(time => time && this.isValidTimeFormat(time))
+					.sort();
+				
+				if (this.scheduledTimes.some(time => time && !this.isValidTimeFormat(time))) {
+					new Notice('Some times are invalid. Please use HH:mm format.');
+					return;
+				}
+
+				this.onSave(validTimes);
+				this.close();
+			});
+	}
+
+	private isValidTimeFormat(time: string): boolean {
+		const regex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
+		return regex.test(time);
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -1,4 +1,4 @@
-import { App, TFile, moment } from 'obsidian';
+import { App, TFile, moment, Notice } from 'obsidian';
 import { MonoTaskNoteSettings } from './settings';
 import { TaskFrontmatter, isTaskFrontmatter } from './types';
 
@@ -110,4 +110,91 @@ export class TaskManager {
             });
         }
     }
+
+	async setRecurringDaysOfMonth(file: TFile): Promise<void> {
+		const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+		
+		if (!frontmatter || !isTaskFrontmatter(frontmatter)) {
+			throw new Error('This file is not a task note');
+		}
+
+		const attributes = frontmatter.attributes || [];
+		if (!attributes.includes('recurring')) {
+			throw new Error('This file is not a recurring task note');
+		}
+
+		const currentDays = frontmatter.recurringDaysOfMonth || [];
+		
+		const { DaysOfMonthPickerModal } = await import('./modals/DaysOfMonthPickerModal');
+		const modal = new DaysOfMonthPickerModal(
+			this.app, 
+			file, 
+			currentDays,
+			async (days: number[]) => {
+				await this.app.fileManager.processFrontMatter(file, (fm) => {
+					fm.recurringDaysOfMonth = days;
+				});
+				new Notice(`Recurring days set: ${days.length > 0 ? days.join(', ') : 'none'}`);
+			}
+		);
+		modal.open();
+	}
+
+	async setRecurringDaysOfWeek(file: TFile): Promise<void> {
+		const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+		
+		if (!frontmatter || !isTaskFrontmatter(frontmatter)) {
+			throw new Error('This file is not a task note');
+		}
+
+		const attributes = frontmatter.attributes || [];
+		if (!attributes.includes('recurring')) {
+			throw new Error('This file is not a recurring task note');
+		}
+
+		const currentDays = frontmatter.recurringDaysOfWeek || [];
+		
+		const { DaysOfWeekPickerModal } = await import('./modals/DaysOfWeekPickerModal');
+		const modal = new DaysOfWeekPickerModal(
+			this.app, 
+			file, 
+			currentDays,
+			async (days: string[]) => {
+				await this.app.fileManager.processFrontMatter(file, (fm) => {
+					fm.recurringDaysOfWeek = days;
+				});
+				new Notice(`Recurring days of week set: ${days.length > 0 ? days.join(', ') : 'none'}`);
+			}
+		);
+		modal.open();
+	}
+
+	async setRecurringScheduledTimes(file: TFile): Promise<void> {
+		const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+		
+		if (!frontmatter || !isTaskFrontmatter(frontmatter)) {
+			throw new Error('This file is not a task note');
+		}
+
+		const attributes = frontmatter.attributes || [];
+		if (!attributes.includes('recurring')) {
+			throw new Error('This file is not a recurring task note');
+		}
+
+		const currentTimes = frontmatter.recurringScheduledTimes || [];
+		
+		const { ScheduledTimesPickerModal } = await import('./modals/ScheduledTimesPickerModal');
+		const modal = new ScheduledTimesPickerModal(
+			this.app, 
+			file, 
+			currentTimes,
+			async (times: string[]) => {
+				await this.app.fileManager.processFrontMatter(file, (fm) => {
+					fm.recurringScheduledTimes = times;
+				});
+				new Notice(`Recurring scheduled times set: ${times.length > 0 ? times.join(', ') : 'none'}`);
+			}
+		);
+		modal.open();
+	}
 }

--- a/src/taskNoteCreator.ts
+++ b/src/taskNoteCreator.ts
@@ -39,6 +39,25 @@ export class TaskNoteCreator {
 		}
 	}
 
+	async createRecurringTaskNote(): Promise<void> {
+		const timestamp = moment().format('x');
+		const fileName = `${timestamp}.md`;
+		
+		const filePath = this.getFilePath(fileName);
+		
+		try {
+			const file = await this.createFile(filePath, fileName);
+			await this.initializeRecurringFrontmatter(file);
+			
+			new Notice(`Recurring task note created: ${file.basename}`);
+			
+			await this.openAndFocusFile(file);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			new Notice(`Failed to create recurring task note: ${msg}`);
+		}
+	}
+
 	private getFilePath(fileName: string): string {
 		if (!this.settings.taskNoteDirectory) {
 			return fileName;
@@ -99,6 +118,20 @@ export class TaskNoteCreator {
 			frontmatter.done ??= false;
 			frontmatter.due_date ??= null;
 			frontmatter.priority ??= 4;
+			frontmatter.scheduled_time ??= null;
+			frontmatter.type ??= 'task';
+		});
+	}
+
+	private async initializeRecurringFrontmatter(file: TFile): Promise<void> {
+		await this.app.fileManager.processFrontMatter(file, (frontmatter: Partial<TaskFrontmatter>) => {
+			frontmatter.attributes = ['recurring'];
+			frontmatter.done ??= false;
+			frontmatter.due_date ??= null;
+			frontmatter.priority ??= 4;
+			frontmatter.recurringDaysOfMonth = [];
+			frontmatter.recurringDaysOfWeek = [];
+			frontmatter.recurringScheduledTimes = [];
 			frontmatter.scheduled_time ??= null;
 			frontmatter.type ??= 'task';
 		});

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,10 +14,14 @@ export interface Commands {
 }
 
 export interface TaskFrontmatter {
+    attributes?: string[]; // For recurring tasks
     done: boolean;
     done_at?: string | null;
     due_date: string | null;
     priority: number;
+    recurringDaysOfMonth?: number[]; // Days of month for recurring tasks (1-31)
+    recurringDaysOfWeek?: string[]; // Days of week for recurring tasks (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
+    recurringScheduledTimes?: string[]; // Scheduled times for recurring tasks (HH:mm format)
     scheduled_time: string | null;
     type: 'task';
     [key: string]: unknown; // Allow additional properties


### PR DESCRIPTION
## Summary
- Added support for recurring tasks with customizable recurrence patterns
- Implemented interactive modals for configuring recurring schedules
- Extended task frontmatter with recurring-specific fields

## Changes
- Added `attributes` field to identify recurring tasks
- Added three new frontmatter fields for recurrence configuration:
  - `recurringDaysOfMonth`: Days of month (1-31)
  - `recurringDaysOfWeek`: Days of week (Mon-Sun)
  - `recurringScheduledTimes`: Times in HH:mm format
- Created three interactive modal components for setting recurrence patterns
- Added new commands for creating and configuring recurring tasks
- Updated README documentation

## Test plan
- [ ] Create a recurring task note using the new command
- [ ] Verify the recurring task has the correct frontmatter fields
- [ ] Test setting recurring days of month modal
- [ ] Test setting recurring days of week modal
- [ ] Test setting recurring scheduled times modal
- [ ] Verify commands only appear for recurring tasks
- [ ] Verify modal values are saved correctly to frontmatter

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create recurring task notes with pre-filled recurring metadata and immediate title editing.
  - New commands and interactive modals to pick days of month, days of week, and scheduled times; commands only apply to notes marked as recurring.
  - Inline validation and user Notices guide setup, confirm updates, and report errors.

- **Documentation**
  - Added Recurring Tasks section detailing required attributes and modal-based configuration.
  - Clarified full compatibility with Obsidian Templates variables and modal-based template selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->